### PR TITLE
night light with right coefficients

### DIFF
--- a/material/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/material/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -28,5 +28,19 @@
     <!-- Boolean indicating whether the HWC setColorTransform function can be performed efficiently
          in hardware. -->
     <bool name="config_setColorTransformAccelerated">true</bool>
-
+     
+    <!-- Enable Night display, which requires HWC 2.0. -->
+    <bool name="config_nightDisplayAvailable">true</bool>
+    <string-array name="config_nightDisplayColorTemperatureCoefficients">
+        <item>0.0</item>
+        <item>0.0</item>
+        <item>1.0</item>
+        <item>-0.000000014365268757</item>
+        <item>0.000255092801250106</item>
+        <item>-0.064156942434907716</item>
+        <item>-0.000000000910931179</item>
+        <item>0.000207598323269139</item>
+        <item>-0.349361641294833436</item>
+    </string-array>
+     
 </resources>


### PR DESCRIPTION
Enables Night Light in settings app and sets right color coefficients.